### PR TITLE
增强网页内容提取器功能

### DIFF
--- a/example/fetch-test.ts
+++ b/example/fetch-test.ts
@@ -1,0 +1,11 @@
+import { WebContentFetcher } from "../src/webContentFetcher.js";
+
+const webContentFetcher = new WebContentFetcher();
+
+// webContentFetcher.fetchAndParse("https://www.baidu.com").then((result) => {
+//   console.log(result);
+// });
+
+webContentFetcher.fetchAndParse("https://www.baidu.com", 0).then((result) => {
+  console.log(result);
+});

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node build/index.js",
-    "test:api": "tsx test-api.ts",
-    "test:debug": "tsx test-debug.ts",
+    "test:fetch": "tsx example/fetch-test.ts",
+    "test:fetch:debug": "tsx --inspect-brk example/fetch-test.ts",
     "clean": "rimraf build",
     "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build",
@@ -36,7 +36,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "cheerio": "^1.1.2"
   },
   "devDependencies": {

--- a/src/webContentFetcher.ts
+++ b/src/webContentFetcher.ts
@@ -15,9 +15,28 @@ export class WebContentFetcher {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 30000);
 
+      const url_ = new URL(url);
+      const url_host = url_.host;
+
       const response = await fetch(url, {
         headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+          'Accept-Language': 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7',
+          'Accept-Encoding': 'gzip, deflate, br, zstd',
+          'Connection': 'keep-alive',
+          'Cache-Control': 'max-age=0',
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'none',
+          'Sec-Fetch-User': '?1',
+          'Upgrade-Insecure-Requests': '1',
+          'Sec-Ch-Ua': '"Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"',
+          'Sec-Ch-Ua-Mobile': '?0',
+          'Sec-Ch-Ua-Platform': '"Windows"',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+          'Referer': `https://www.google.com?q=${url_host}`,
+          'Origin': 'https://www.google.com',
+          'Priority': 'u=0, i',
         },
         redirect: 'follow',
         signal: controller.signal
@@ -29,18 +48,39 @@ export class WebContentFetcher {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      const html = await response.text();
+      // Fetch API automatically handles decompression for standard encodings
+      // (gzip, deflate, br, zstd) so response.text() returns decompressed content
+      let html: string;
+
+      try {
+        html = await response.text();
+      } catch (decodeError) {
+        const buffer = await response.arrayBuffer();
+        const decoder = new TextDecoder('utf-8', { fatal: false });
+        html = decoder.decode(buffer);
+      }
+
+      // Verify we got valid content
+      if (!html || html.length === 0) {
+        throw new Error('Received empty response from server');
+      }
+
       const $ = cheerio.load(html);
 
       // Remove script and style elements
-      $('script, style, nav, header, footer').remove();
+      $('script, style, nav, header, footer, meta').remove();
 
       // Get the text content
-      const text = $.text();
+      let text = $.text();
+      const $2 = cheerio.load(text);
+      $2('script, style, nav, header, footer, meta').remove();
+      if ($2.text()) {
+        text = $2.text();
+      }
 
       // Clean up the text
       const lines = text.split('\n').map((line: string) => line.trim());
-      const chunks = lines.flatMap((line: string) => 
+      const chunks = lines.flatMap((line: string) =>
         line.split(/\s{2,}/).map((phrase: string) => phrase.trim())
       );
       let cleanText = chunks.filter((chunk: string) => chunk).join(' ');
@@ -48,8 +88,43 @@ export class WebContentFetcher {
       // Remove extra whitespace
       cleanText = cleanText.replace(/\s+/g, ' ').trim();
 
+      // Extract and append links with their text content
+      const a_tags = $('a');
+      const links: string[] = [];
+      
+      a_tags.each((_, element) => {
+        const href = $(element).attr('href');
+        if (!href) return;
+        
+        // Convert relative URLs to absolute URLs
+        let absoluteUrl: string;
+        try {
+          // Use URL constructor to handle all types of relative URLs
+          const resolvedUrl = new URL(href, url);
+          absoluteUrl = resolvedUrl.href;
+        } catch (error) {
+          return;
+        }
+        
+        // Get the link text content
+        const linkText = $(element).text().trim();
+        
+        // Skip if no meaningful text or if it's just the original href
+        if (!linkText || linkText === href) return;
+        
+        // Format the link with absolute URL
+        const formattedLink = `[${linkText}](${absoluteUrl})`;
+        links.push(formattedLink);
+      });
+      
+      // Append unique links to the content
+      if (links.length > 0) {
+        const uniqueLinks = [...new Set(links)];
+        cleanText += '\n\n**Links:**\n' + uniqueLinks.join('\n');
+      }
+
       // Truncate if too long
-      if (cleanText.length > max_content_length) {
+      if (max_content_length && cleanText.length > max_content_length) {
         cleanText = cleanText.substring(0, max_content_length) + '... [content truncated]';
       }
 


### PR DESCRIPTION
## 变更内容

- 新增 `example/fetch-test.ts` 文件用于测试网页内容提取功能
- 更新 `package.json`:
  - 将 `@modelcontextprotocol/sdk` 依赖从 `^1.17.5` 升级至 `^1.18.1`
  - 修改测试脚本名称：`test:api` 改为 `test:fetch`，`test:debug` 改为 `test:fetch:debug`
- 修改 `src/webContentFetcher.ts`:
  - 增强 HTTP 请求头，添加更多浏览器模拟字段以提高兼容性
  - 改进响应内容解码逻辑，增加对解码失败的容错处理
  - 增加对空响应内容的校验
  - 在清理 HTML 内容时额外移除 `meta` 标签
  - 增加链接提取功能，将页面中的链接及其文本内容格式化后附加到结果中
  - 修复内容截断逻辑，确保 `max_content_length` 参数为 0 时不进行截断

## 变更原因

- 提升网页内容提取的准确性和稳定性
- 增强对不同网站的兼容性，通过更完整的浏览器请求头模拟
- 添加链接提取功能以提供更丰富的网页信息
- 修复潜在的内容处理异常，提高代码健壮性
- 更新依赖以使用最新功能和修复

## 测试方法

1. 运行 `npm run test:fetch` 执行示例测试脚本，验证网页内容提取功能
2. 运行 `npm run test:fetch:debug` 启动调试模式进行断点调试
3. 检查控制台输出，确认返回的网页内容包含提取的文本和链接信息
4. 验证不同网页的提取结果，确保功能正常且无异常报错